### PR TITLE
Support for multiple environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Here's how to set a custom environment file name in your `hurl.nvim` setup:
 ```lua
 require('hurl').setup({
   -- Specify your custom environment file name here
-  env_file = 'hurl.env',
+  env_file = {
+      'hurl.env',
+  },
   -- Other configuration options...
 })
 ```
@@ -89,7 +91,7 @@ By checking these locations, the plugin ensures a comprehensive search for envir
 
 ### Swappable environment
 
-To change the environment file name, use the `HurlSetEnvFile` command followed by the new file name.
+To change the environment file name, use the `HurlSetEnvFile` command followed by the new file name. You can have multiple variable files by having comma-seperated values.
 
 #### Notes
 
@@ -172,7 +174,9 @@ local default_config = {
   },
 
   -- Default environment file name
-  env_file = 'vars.env',
+  env_file = {
+      'vars.env',
+  },
 
   -- Specify formatters for different response types
   formatters = {
@@ -192,7 +196,7 @@ To apply these configurations, include them in your Neovim setup like this:
 require('hurl').setup({
   debug = true,          -- Enable to show detailed logs
   mode = 'popup',        -- Change to 'popup' to display responses in a popup window
-  env_file = 'vars.env', -- Change this to use a different environment file name
+  env_file = { 'vars.env' }, -- Change this to use a different environment file name
   formatters = {
     json = { 'jq' },    -- Customize the JSON formatter command
     html = {

--- a/lua/hurl/init.lua
+++ b/lua/hurl/init.lua
@@ -11,7 +11,7 @@ local default_config = {
     width = 80,
     height = 40,
   },
-  env_file = 'vars.env',
+  env_file = { 'vars.env' },
   formatters = {
     json = { 'jq' },
     html = {
@@ -30,6 +30,10 @@ local M = {}
 --       - debug: (boolean | nil) default: false.
 --       - mode: ('popup' | 'split') default: popup.
 function M.setup(options)
+  if options.env_file ~= nil and type(options.env_file) == 'string' then
+    options.env_file = { options.env_file }
+  end
+
   _HURL_GLOBAL_CONFIG = vim.tbl_extend('force', _HURL_GLOBAL_CONFIG, options or default_config)
 
   require('hurl.main').setup()

--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -354,7 +354,10 @@ function M.setup()
       return
     end
     _HURL_GLOBAL_CONFIG.env_file = vim.split(env_file, ',')
-    vim.notify('hurl: env file changed to ' .. _HURL_GLOBAL_CONFIG.env_file, vim.log.levels.INFO)
+    vim.notify(
+      'hurl: env file changed to ' .. vim.inspect(_HURL_GLOBAL_CONFIG.env_file),
+      vim.log.levels.INFO
+    )
   end, { nargs = '*', range = true })
 
   -- Run Hurl in verbose mode and send output to quickfix

--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -13,12 +13,15 @@ local function find_env_files_in_folders()
   local root_dir = vim.fn.expand('%:p:h')
   local cache_dir = vim.fn.stdpath('cache')
   local current_file_dir = vim.fn.expand('%:p:h:h')
-  local env_files = {
-    {
-      path = root_dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-      dest = cache_dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-    },
-  }
+  local env_files = {}
+
+  for _, file in ipairs(_HURL_GLOBAL_CONFIG.env_file) do
+    table.insert(env_files, {
+      path = root_dir .. '/' .. file,
+      dest = cache_dir .. '/' .. file,
+    })
+  end
+
   -- NOTE: it may be better to use a user config to define the scan directories
   local scan_dir = {
     {
@@ -44,10 +47,13 @@ local function find_env_files_in_folders()
   -- Scan git root directory and all sub directories with the current file buffer
   if git.is_git_repo() then
     local git_root = git.get_git_root()
-    table.insert(env_files, {
-      path = git_root .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-      dest = cache_dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-    })
+
+    for _, file in ipairs(_HURL_GLOBAL_CONFIG.env_file) do
+      table.insert(env_files, {
+        path = git_root .. '/' .. file,
+        dest = cache_dir .. '/' .. file,
+      })
+    end
 
     local git_root_parts = git.split_path(git_root)
     local current_dir_parts = git.split_path(current_file_dir)
@@ -55,20 +61,25 @@ local function find_env_files_in_folders()
 
     for i = #git_root_parts + 1, #current_dir_parts do
       sub_path = sub_path .. '/' .. current_dir_parts[i]
-      table.insert(env_files, {
-        path = sub_path .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-        dest = cache_dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-      })
+
+      for _, file in ipairs(_HURL_GLOBAL_CONFIG.env_file) do
+        table.insert(env_files, {
+          path = sub_path .. '/' .. file,
+          dest = cache_dir .. '/' .. file,
+        })
+      end
     end
   end
 
   for _, s in ipairs(scan_dir) do
     local dir = root_dir .. s.dir
     if vim.fn.isdirectory(dir) == 1 then
-      table.insert(env_files, {
-        path = dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-        dest = cache_dir .. '/' .. _HURL_GLOBAL_CONFIG.env_file,
-      })
+      for _, file in ipairs(_HURL_GLOBAL_CONFIG.env_file) do
+        table.insert(env_files, {
+          path = dir .. '/' .. file,
+          dest = cache_dir .. '/' .. file,
+        })
+      end
     end
   end
 
@@ -149,9 +160,13 @@ local function execute_hurl_cmd(opts, callback)
   -- Then inject the command with --variables-file vars.env
   local env_files = find_env_files_in_folders()
   for _, env in ipairs(env_files) do
-    utils.log_info('hurl: looking for ' .. _HURL_GLOBAL_CONFIG.env_file .. ' in ' .. env.path)
+    utils.log_info(
+      'hurl: looking for ' .. vim.inspect(_HURL_GLOBAL_CONFIG.env_file) .. ' in ' .. env.path
+    )
     if vim.fn.filereadable(env.path) == 1 then
-      utils.log_info('hurl: found ' .. _HURL_GLOBAL_CONFIG.env_file .. ' in ' .. env.path)
+      utils.log_info(
+        'hurl: found ' .. vim.inspect(_HURL_GLOBAL_CONFIG.env_file) .. ' in ' .. env.path
+      )
       table.insert(opts, '--variables-file')
       table.insert(opts, env.path)
       break
@@ -338,7 +353,7 @@ function M.setup()
       vim.notify('hurl: please provide the env file name', vim.log.levels.INFO)
       return
     end
-    _HURL_GLOBAL_CONFIG.env_file = env_file
+    _HURL_GLOBAL_CONFIG.env_file = vim.split(env_file, ',')
     vim.notify('hurl: env file changed to ' .. _HURL_GLOBAL_CONFIG.env_file, vim.log.levels.INFO)
   end, { nargs = '*', range = true })
 


### PR DESCRIPTION
## WHAT

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY

Adds passing multiple environment variables where a user might need to commit the common ones and have their specific environment overriding it.

As discussed before in #23 which is partially implemented.

## HOW

Converts the `env_file` field into a table from a string. The old configuration for the users will not break because whenever the user is doing the module setup, it will also convert it automatically to the new form.

For `HurlSetEnvFile` command, it also expects comma-separeted values if you do want to pass multiple files.

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Linter
- [x] Tests
- [ ] Review comments
- [ ] Security
