### PR TITLE
Patch 1

### DIFF
--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -145,7 +145,7 @@ end
 ---@return boolean
 util.is_json_response = function(content_type)
   return string.find(content_type, 'application/json') ~= nil or 
-         string.find(content_type, 'application/vnd.api+json') ~= nil
+         string.find(content_type, 'application/vnd.api%+json') ~= nil
 end
 
 

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -144,8 +144,10 @@ end
 ---@param content_type string
 ---@return boolean
 util.is_json_response = function(content_type)
-  return string.find(content_type, 'application/json') ~= nil
+  return string.find(content_type, 'application/json') ~= nil or 
+         string.find(content_type, 'application/vnd.api+json') ~= nil
 end
+
 
 util.is_html_response = function(content_type)
   return string.find(content_type, 'text/html') ~= nil

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -148,7 +148,6 @@ util.is_json_response = function(content_type)
          string.find(content_type, 'application/vnd.api%+json') ~= nil
 end
 
-
 util.is_html_response = function(content_type)
   return string.find(content_type, 'text/html') ~= nil
 end


### PR DESCRIPTION
## WHAT

Detect JSON:API content-type

## WHY

JSON:API returns valid JSON but uses a different content type.  Update the is_json_response function to handle both cases

## HOW

Match "content-type: application/vnd.api+json"

## Types of changes

- [X ] New feature (non-breaking change which adds functionality)
