### PR TITLE
Fix HurlRunnterToEntry using treesitter

### DIFF
--- a/lua/hurl/http_utils.lua
+++ b/lua/hurl/http_utils.lua
@@ -1,103 +1,55 @@
 local M = {}
 
---- Find the HTTP verb in the given line
----@param line string
----@param current_line_number number
-local function find_http_verb(line, current_line_number)
-  if not line then
-    return nil
-  end
-
-  local verbs = { 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' }
-  local verb_start, verb_end, verb
-
-  for _, v in ipairs(verbs) do
-    verb_start, verb_end = line:find(v)
-    if verb_start then
-      verb = v
-      break
-    end
-  end
-
-  if verb_start then
-    return {
-      line_number = current_line_number,
-      start_pos = verb_start,
-      end_pos = verb_end,
-      method = verb,
-    }
-  else
-    return nil
-  end
-end
-
 --- Find the closest HURL entry at the current cursor position.
 local function find_hurl_entry_positions_in_buffer()
   local ts = vim.treesitter
-  local node = ts.get_node()
 
-  while node and node:type() ~= 'entry' do
-    node = node:parent()
+  -- Look for closest `entry` node to cursor position.
+  local current_node = ts.get_node()
+  while current_node and current_node:type() ~= 'entry' do
+    current_node = current_node:parent()
   end
 
-  if not node then
+  if not current_node then
+    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
     return {
       current = 0,
-      start_line = nil,
-      end_line = nil,
+      start_line = cursor_line,
+      end_line = cursor_line,
     }
   else
-    local r1, _, _ = node:start()
-    local r2, _, _ = node:end_()
+    local r1, _, _ = current_node:start()
+    local r2, _, _ = current_node:end_()
+
+    local hurl_file = current_node:parent()
+
+    local current_node_idx = 1
+    if (hurl_file and hurl_file:type() == 'hurl_file') then
+      -- Find the current node index
+      for node in hurl_file:iter_children() do
+        if (node:id() == current_node:id()) then
+          break
+        end
+        current_node_idx = current_node_idx + 1
+      end
+    else
+      -- Parent node is not a hurl_file, HURL file must have errors.
+      local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+      return {
+        current = 0,
+        start_line = cursor_line,
+        end_line = cursor_line
+      }
+    end
+
     return {
-      current = r1 + 1,
+      current = current_node_idx,
       start_line = r1 + 1,
       end_line = r2 + 1,
     }
   end
 end
 
---- Find the HTTP verbs in the current buffer
----@return table
-local function find_http_verb_positions_in_buffer()
-  local buf = vim.api.nvim_get_current_buf()
-  local total_lines = vim.api.nvim_buf_line_count(buf)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local current_line_number = cursor[1]
-
-  local next_entry = 0
-  local current_index = 0
-  local current_verb = nil
-  local end_line = total_lines -- Default to the last line of the buffer
-
-  for i = 1, total_lines do
-    local line = vim.api.nvim_buf_get_lines(buf, i - 1, i, false)[1]
-    local result = find_http_verb(line, i)
-    if result then
-      next_entry = next_entry + 1
-      if i == current_line_number then
-        current_index = next_entry
-        current_verb = result
-      elseif current_verb and i > current_verb.line_number then
-        end_line = i - 1 -- The end line of the current verb is the line before the next verb starts
-        break -- No need to continue once the end line of the current verb is found
-      end
-    end
-  end
-
-  if current_verb and current_index == next_entry then
-    -- If the current verb is the last one, the end line is the last line of the buffer
-    end_line = total_lines
-  end
-
-  return {
-    current = current_index,
-    start_line = current_verb and current_verb.line_number or nil,
-    end_line = end_line,
-  }
-end
-
-M.find_http_verb_positions_in_buffer = find_http_verb_positions_in_buffer
 M.find_hurl_entry_positions_in_buffer = find_hurl_entry_positions_in_buffer
 
 return M

--- a/lua/hurl/http_utils.lua
+++ b/lua/hurl/http_utils.lua
@@ -24,10 +24,10 @@ local function find_hurl_entry_positions_in_buffer()
     local hurl_file = current_node:parent()
 
     local current_node_idx = 1
-    if (hurl_file and hurl_file:type() == 'hurl_file') then
+    if hurl_file and hurl_file:type() == 'hurl_file' then
       -- Find the current node index
       for node in hurl_file:iter_children() do
-        if (node:id() == current_node:id()) then
+        if node:id() == current_node:id() then
           break
         end
         current_node_idx = current_node_idx + 1
@@ -38,7 +38,7 @@ local function find_hurl_entry_positions_in_buffer()
       return {
         current = 0,
         start_line = cursor_line,
-        end_line = cursor_line
+        end_line = cursor_line,
       }
     end
 

--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -360,7 +360,7 @@ function M.setup()
 
   -- Run request to current entry if there is a HTTP method
   utils.create_cmd('HurlRunnerToEntry', function(opts)
-    local result = http.find_http_verb_positions_in_buffer()
+    local result = http.find_hurl_entry_positions_in_buffer()
     if result.current > 0 then
       opts.fargs = opts.fargs or {}
       opts.fargs = vim.list_extend(opts.fargs, { '--to-entry', result.current })


### PR DESCRIPTION
## WHAT

Modify HurlRunnerToEntry to work using treesitter parser.  This allows to run to a specific entry without having to be exactly located at the start of the entry where the verb is located.

## WHY

## HOW

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security
