### PR TITLE
fix: update the implementation method of obtaining the git root direc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Add the following configuration to your Neovim setup with [lazy.nvim](https://gi
   "jellydn/hurl.nvim",
   dependencies = {
       "MunifTanjim/nui.nvim",
+      "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter"
   },
   ft = "hurl",

--- a/lua/hurl/git_utils.lua
+++ b/lua/hurl/git_utils.lua
@@ -11,8 +11,10 @@ end
 --- Get the git root directory
 ---@return string|nil The git root directory
 local function get_git_root()
-  local dot_git_path = vim.fn.finddir('.git', '.;')
-  return vim.fn.fnamemodify(dot_git_path, ':h')
+  local git_root_path = require('plenary.job')
+    :new({ command = 'git', args = { 'rev-parse', '--show-toplevel' } })
+    :sync()[1]
+  return git_root_path
 end
 
 local function split_path(path)


### PR DESCRIPTION

The path returned by function get_git_root is always ".", resulting in the Env file not being found.

![image](https://github.com/jellydn/hurl.nvim/assets/4506063/eea60af3-7a1f-4dda-b6f6-d1a81d19cb65)


