### PR TITLE
fix(hurl): fold not work if set foldexpr to `vim.treesitter.foldexpr()`

### DIFF
--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -5,9 +5,6 @@ local split = Split({
   relative = 'editor',
   position = _HURL_GLOBAL_CONFIG.split_position,
   size = _HURL_GLOBAL_CONFIG.split_size,
-  -- Create a custom filetype so that we can use https://github.com/folke/edgy.nvim to manage the window
-  -- E.g: { title = "Hurl Nvim", ft = "hurl-nvim" },
-  buf_options = { filetype = 'hurl-nvim' },
 })
 
 local utils = require('hurl.utils')
@@ -22,6 +19,15 @@ local M = {}
 M.show = function(data, type)
   -- mount/open the component
   split:mount()
+  -- If have edgy.nvim
+  if pcall(require, 'edgy') then
+    -- Create a custom filetype so that we can use https://github.com/folke/edgy.nvim to manage the window
+    -- E.g: { title = "Hurl Nvim", ft = "hurl-nvim" },
+    vim.api.nvim_buf_set_option(split.bufnr, 'filetype', 'hurl-nvim')
+  end
+
+  -- Set content to highlight, refer https://github.com/MunifTanjim/nui.nvim/issues/76#issuecomment-1001358770
+  vim.api.nvim_buf_set_option(split.bufnr, 'filetype', type)
 
   if _HURL_GLOBAL_CONFIG.auto_close then
     -- unmount component when buffer is closed
@@ -57,9 +63,6 @@ M.show = function(data, type)
   split:map('n', 'q', function()
     quit()
   end)
-
-  -- Set content to highlight, refer https://github.com/MunifTanjim/nui.nvim/issues/76#issuecomment-1001358770
-  vim.api.nvim_buf_set_option(split.bufnr, 'filetype', type)
 end
 
 M.clear = function()


### PR DESCRIPTION
Set filetype to `hurl-nvim` by default make `vim.treesitter.foldexpr()` not work, causes zc zo to fail in response buffer, it happens only on nvim 0.10. this commit check if edgy.nvim exists and then set filetype to hurl-nvim, otherwise just set filetype to input param `type`.

Also I was wondering if there have any way to set buf name safety with nui.nvim?

I tried to use `vim.api.nvim_buf_set_name(split.bufnr, 'hurl-response')` at split.show, but got a error when run a request second time, it seems like bufnr got wrong value or something. I would love to make a PR if I can fix it, right now the split result window have no name, maybe add a name will be nice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved buffer filetype handling, ensuring compatibility with `edgy.nvim` when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->