### PR TITLE
feat(hurl): add buffer name for split response window

### DIFF
--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -23,6 +23,8 @@ M.show = function(data, type)
   -- mount/open the component
   split:mount()
 
+  vim.api.nvim_buf_set_name(split.bufnr, 'hurl-response')
+
   if _HURL_GLOBAL_CONFIG.auto_close then
     -- unmount component when buffer is closed
     split:on(event.BufLeave, function()
@@ -51,6 +53,8 @@ M.show = function(data, type)
   vim.api.nvim_buf_set_lines(split.bufnr, headers_table.line, -1, false, content)
 
   local function quit()
+    -- set buffer name to empty string so it wouldn't conflict when next time buffer opened
+    vim.api.nvim_buf_set_name(split.bufnr, '')
     vim.cmd('q')
     split:unmount()
   end


### PR DESCRIPTION
## WHAT
add a buffer name for split response window, like #162 mentioned. 
<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY

## HOW

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved buffer name conflicts by setting the buffer name to 'hurl-response' when displaying the split view and clearing it before quitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->