### PR TITLE
fix(split): no fold find if foldexpr setup

### DIFF
--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -57,6 +57,8 @@ M.show = function(data, type)
   -- After 200ms, the highlight will be applied
   vim.defer_fn(function()
     vim.bo[split.bufnr].filetype = type
+    -- recomputing foldlevel, this is needed if we setup foldexpr
+    vim.api.nvim_feedkeys('zx', 'n', true)
   end, 200)
 
   local function quit()


### PR DESCRIPTION
## WHAT
foldlevel computing can manually trigger with `zx`, so we just need recompute foldlevel after setup filetype to json | html | text
related #162 
<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY

## HOW

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of fold levels after setting the filetype to ensure proper folding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->