### PR TITLE
fix(spinner): use global config for show_notification

### DIFF
--- a/lua/hurl/spinner.lua
+++ b/lua/hurl/spinner.lua
@@ -7,9 +7,6 @@ local M = {}
 
 -- User configuration section
 local config = {
-  -- Show notification when done.
-  -- Set to false to disable.
-  show_notification = true,
   -- Name of the plugin.
   plugin = 'hurl.nvim',
   -- Spinner frames.
@@ -84,7 +81,7 @@ function M.hide(show_msg)
       vim.api.nvim_buf_delete(spinner_buf, { force = true })
     end
 
-    if config.show_notification or show_msg then
+    if show_msg or _HURL_GLOBAL_CONFIG.show_notification then
       vim.notify('Done!', vim.log.levels.INFO, { title = config.plugin })
     end
   end


### PR DESCRIPTION
## WHAT

spinner didn't honor `show_notification`

## WHY

to avoid "Done!" message

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security
