### PR TITLE
feat: add xml type for response formatting and highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Add the following configuration to your Neovim setup with [lazy.nvim](https://gi
         '--parser',
         'html',
       },
+      xml = {
+        'tidy', -- Make sure you have installed tidy in your system, e.g: brew install tidy-html5
+        '-xml',
+        '-i',
+        '-q',
+      },
     },
   },
   keys = {
@@ -251,6 +257,12 @@ local default_config = {
       '--parser',
       'html',
     },
+    xml = {
+      'tidy',         -- Uses tidy to format XML responses
+      '-xml',
+      '-i',
+      '-q',
+    },
   },
 }
 ```
@@ -268,6 +280,12 @@ require('hurl').setup({
       'prettier',       -- Customize the HTML formatter command
       '--parser',
       'html',
+    },
+    xml = {
+      'tidy',           -- Customize the XML formatter command
+      '-xml',
+      '-i',
+      '-q',
     },
   },
 })

--- a/doc/hurl.nvim.txt
+++ b/doc/hurl.nvim.txt
@@ -66,7 +66,7 @@ Add the following configuration to your Neovim setup with lazy.nvim
             'html',
           },
           xml = {
-            'tidy', -- Make sure you have install prettier in your system, e.g: npm install -g prettier
+            'tidy', -- Make sure you have installed tidy in your system, e.g: brew install tidy-html5
             '-xml',
             '-i',
             '-q',

--- a/doc/hurl.nvim.txt
+++ b/doc/hurl.nvim.txt
@@ -65,6 +65,12 @@ Add the following configuration to your Neovim setup with lazy.nvim
             '--parser',
             'html',
           },
+          xml = {
+            'tidy', -- Make sure you have install prettier in your system, e.g: npm install -g prettier
+            '-xml',
+            '-i',
+            '-q',
+          },
         },
       },
       keys = {
@@ -326,6 +332,12 @@ CONFIGURATION                                        *hurl.nvim-configuration*
           '--parser',
           'html',
         },
+        xml = {
+          'tidy',         -- Uses tidy to format XML responses
+          '-xml',
+          '-i',
+          '-q',
+        },
       },
     }
 <
@@ -343,6 +355,12 @@ To apply these configurations, include them in your Neovim setup like this:
           'prettier',       -- Customize the HTML formatter command
           '--parser',
           'html',
+        },
+        xml = {
+          'tidy',       -- Customize the XML formatter command
+          '-xml',
+          '-i',
+          '-q',
         },
       },
     })

--- a/lua/hurl/history.lua
+++ b/lua/hurl/history.lua
@@ -26,7 +26,11 @@ M.show = function(response)
     if utils.is_html_response(content_type) then
       container.show(response, 'html')
     else
-      container.show(response, 'text')
+      if utils.is_xml_response(content_type) then
+        container.show(response, 'xml')
+      else
+        container.show(response, 'text')
+      end
     end
   end
 end

--- a/lua/hurl/init.lua
+++ b/lua/hurl/init.lua
@@ -23,6 +23,12 @@ local default_config = {
       '--parser',
       'html',
     },
+    xml = {
+      'tidy',
+      '-xml',
+      '-i',
+      '-q',
+    },
   },
 }
 --- Global configuration for entire plugin, easy to access from anywhere

--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -183,7 +183,11 @@ local function execute_hurl_cmd(opts, callback)
           if utils.is_html_response(content_type) then
             container.show(response, 'html')
           else
-            container.show(response, 'text')
+            if utils.is_xml_response(content_type) then
+              container.show(response, 'xml')
+            else
+              container.show(response, 'text')
+            end
           end
         end
       end

--- a/lua/hurl/popup.lua
+++ b/lua/hurl/popup.lua
@@ -35,7 +35,7 @@ local layout = Layout(
 ---@param data table
 ---   - body string
 ---   - headers table
----@param type 'json' | 'html' | 'text'
+---@param type 'json' | 'html' | 'xml' | 'text'
 M.show = function(data, type)
   layout:mount()
 

--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -15,7 +15,7 @@ local M = {}
 ---@param data table
 ---   - body string
 ---   - headers table
----@param type 'json' | 'html' | 'text'
+---@param type 'json' | 'html' | 'xml' | 'text'
 M.show = function(data, type)
   -- mount/open the component
   split:mount()

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -105,7 +105,11 @@ end
 ---@return string[] | nil
 util.format = function(body, type)
   local formatters = _HURL_GLOBAL_CONFIG.formatters
-      or { json = { 'jq' }, html = { 'prettier', '--parser', 'html' }, xml = { 'tidy', '-xml', '-i', '-q' } }
+    or {
+      json = { 'jq' },
+      html = { 'prettier', '--parser', 'html' },
+      xml = { 'tidy', '-xml', '-i', '-q' },
+    }
 
   -- If no formatter is defined, return the body
   if not formatters[type] then
@@ -172,7 +176,7 @@ end
 
 util.is_xml_response = function(content_type)
   return string.find(content_type, 'text/xml') ~= nil
-      or string.find(content_type, 'application/xml') ~= nil
+    or string.find(content_type, 'application/xml') ~= nil
 end
 
 --- Check if nvim is running in nightly or stable version

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -172,6 +172,7 @@ end
 
 util.is_xml_response = function(content_type)
   return string.find(content_type, 'text/xml') ~= nil
+      or string.find(content_type, 'application/xml') ~= nil
 end
 
 --- Check if nvim is running in nightly or stable version

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -101,11 +101,11 @@ end
 
 --- Format the body of the request
 ---@param body string
----@param type 'json' | 'html' | 'text'
+---@param type 'json' | 'html' | 'xml' | 'text'
 ---@return string[] | nil
 util.format = function(body, type)
   local formatters = _HURL_GLOBAL_CONFIG.formatters
-    or { json = { 'jq' }, html = { 'prettier', '--parser', 'html' } }
+      or { json = { 'jq' }, html = { 'prettier', '--parser', 'html' }, xml = { 'tidy', '-xml', '-i', '-q' } }
 
   -- If no formatter is defined, return the body
   if not formatters[type] then
@@ -168,6 +168,10 @@ end
 
 util.is_html_response = function(content_type)
   return string.find(content_type, 'text/html') ~= nil
+end
+
+util.is_xml_response = function(content_type)
+  return string.find(content_type, 'text/xml') ~= nil
 end
 
 --- Check if nvim is running in nightly or stable version


### PR DESCRIPTION
## WHAT

Add support for XML response content types.

## WHY

Though not as common as HTML or JSON APIs, XML is still widely used.

Handling it as generic `text` works currently, but no response formatting or syntax highlighting is being done.

## HOW

Adding the relevant function `utils.is_xml_response(content_type)` and type handling for formatting (with `tidy` command) and syntax highlighting the response.

Probably a more generic and extensible way of allowing plugin users to configure custom formatting commands for different response types would be better. But, in this case I didn't want to change too much the internal logic of the plugin, just add support for XML.

## Screenshots (if appropriate):

A formatted and syntax highlighted response example:

![Screenshot 2024-07-09 at 12 11 13](https://github.com/jellydn/hurl.nvim/assets/11479916/0015a737-330c-4abf-84ec-274fc9a877f7)

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced XML formatting configuration using `tidy` for improved XML parsing and display.
  
- **Improvements**
  - Enhanced `show` function to support displaying XML responses alongside existing JSON, HTML, and text formats.
  - Added new function to check for XML response content types, ensuring accurate content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->