### PR TITLE
Add possibility to customize request view mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Add the following configuration to your Neovim setup with [lazy.nvim](https://gi
         '-q',
       },
     },
+    -- Default mappings for the response popup or split views
+    mappings = {
+      close = 'q', -- Close the response popup or split view
+      next_panel = '<C-n>', -- Move to the next response popup window
+      prev_panel = '<C-p>', -- Move to the previous response popup window
+    },
   },
   keys = {
     -- Run API request

--- a/doc/hurl.nvim.txt
+++ b/doc/hurl.nvim.txt
@@ -77,6 +77,12 @@ Add the following configuration to your Neovim setup with lazy.nvim
             '-q',
           },
         },
+        -- Default mappings for the response popup or split views
+          mappings = {
+          close = 'q', -- Close the response popup or split view
+          next_panel = '<C-n>', -- Move to the next response popup window
+          prev_panel = '<C-p>', -- Move to the previous response popup window
+        },
       },
       keys = {
         -- Run API request
@@ -337,12 +343,15 @@ DEFAULT KEY MAPPINGS                          *hurl.nvim-default-key-mappings*
 
 `hurl.nvim` comes with some default key mappings to streamline your workflow:
 
-- `q`: Close the current popup window.
+- `q`: Close the current popup window or split.
 - `<C-n>`: Switch to the next popup window.
 - `<C-p>`: Switch to the previous popup window.
 
 These key mappings are active within the popup windows that `hurl.nvim`
 displays.
+
+The mappings can be customized in the configuration table passed to the setup
+function.
 
 
 CONFIGURATION                                        *hurl.nvim-configuration*
@@ -396,6 +405,11 @@ CONFIGURATION                                        *hurl.nvim-configuration*
           '-q',
         },
       },
+      mappings = {
+        close = 'q',
+        next_panel = '<C-n>',
+        prev_panel = '<C-p>',
+      },
     }
 <
 
@@ -419,6 +433,9 @@ To apply these configurations, include them in your Neovim setup like this:
           '-i',
           '-q',
         },
+      },
+      mappings = {
+        close = '<C-c>',
       },
     })
 <

--- a/lua/hurl/init.lua
+++ b/lua/hurl/init.lua
@@ -45,6 +45,12 @@ local default_config = {
       '-q',
     },
   },
+  -- Default mappings for the response popup or split views
+  mappings = {
+    close = 'q', -- Close the response popup or split view
+    next_panel = '<C-n>', -- Move to the next response popup window
+    prev_panel = '<C-p>', -- Move to the previous response popup window
+  },
 }
 --- Global configuration for entire plugin, easy to access from anywhere
 _HURL_GLOBAL_CONFIG = default_config
@@ -60,7 +66,7 @@ function M.setup(options)
     options.env_file = { options.env_file }
   end
 
-  _HURL_GLOBAL_CONFIG = vim.tbl_extend('force', _HURL_GLOBAL_CONFIG, options or default_config)
+  _HURL_GLOBAL_CONFIG = vim.tbl_deep_extend('force', _HURL_GLOBAL_CONFIG, options or default_config)
 
   require('hurl.main').setup()
 end

--- a/lua/hurl/popup.lua
+++ b/lua/hurl/popup.lua
@@ -62,25 +62,25 @@ M.show = function(data, type)
   end
 
   -- Map q to quit
-  popups.top:map('n', 'q', function()
+  popups.top:map('n', _HURL_GLOBAL_CONFIG.mappings.close, function()
     quit()
   end)
-  popups.bottom:map('n', 'q', function()
+  popups.bottom:map('n', _HURL_GLOBAL_CONFIG.mappings.close, function()
     quit()
   end)
 
   -- Map <Ctr-n> to next popup
-  popups.top:map('n', '<C-n>', function()
+  popups.top:map('n', _HURL_GLOBAL_CONFIG.mappings.next_panel, function()
     vim.api.nvim_set_current_win(popups.bottom.winid)
   end)
-  popups.bottom:map('n', '<C-n>', function()
+  popups.bottom:map('n', _HURL_GLOBAL_CONFIG.mappings.next_panel, function()
     vim.api.nvim_set_current_win(popups.top.winid)
   end)
   -- Map <Ctr-p> to previous popup
-  popups.top:map('n', '<C-p>', function()
+  popups.top:map('n', _HURL_GLOBAL_CONFIG.mappings.prev_panel, function()
     vim.api.nvim_set_current_win(popups.bottom.winid)
   end)
-  popups.bottom:map('n', '<C-p>', function()
+  popups.bottom:map('n', _HURL_GLOBAL_CONFIG.mappings.prev_panel, function()
     vim.api.nvim_set_current_win(popups.top.winid)
   end)
 

--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -81,7 +81,7 @@ M.show = function(data, type)
     vim.cmd('q')
     split:unmount()
   end
-  split:map('n', 'q', function()
+  split:map('n', _HURL_GLOBAL_CONFIG.mappings.close, function()
     quit()
   end)
 end


### PR DESCRIPTION
Closes issue #184 by adding a `mappings` section to the `_HURL_GLOBAL_CONFIG` table and using the individual mappings when registering mappings for the `split` and `popup` response views.

*Note*: `vim.tbl_extend` has been replaced with `vim.tbl_deep_extend` when merging the *default* and *user provided* config tables to ensure also partial custom user mappings are possible. This also affects other settings. I hope this is OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced customizable keyboard shortcuts for managing response popups in Neovim, including shortcuts for closing popups and navigating between them.
  
- **Documentation**
  - Updated documentation to reflect new configuration options and provide clearer guidance on customizing key mappings for the `hurl.nvim` plugin.
  
- **Refactor**
  - Enhanced flexibility in handling key mappings by using a centralized configuration object, improving maintainability and configurability of popup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->