### PR TITLE
Fix: error when closing the result buffer and trying to reopen it

### DIFF
--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -36,7 +36,6 @@ M.show = function(data, type)
     -- unmount component when buffer is closed
     split:on(event.BufLeave, function()
       quit()
-      -- split:unmount()
     end)
   end
 

--- a/lua/hurl/split.lua
+++ b/lua/hurl/split.lua
@@ -17,6 +17,12 @@ local M = {}
 ---   - headers table
 ---@param type 'json' | 'html' | 'xml' | 'text'
 M.show = function(data, type)
+  local function quit()
+    -- set buffer name to empty string so it wouldn't conflict when next time buffer opened
+    vim.api.nvim_buf_set_name(split.bufnr, '')
+    vim.cmd('q')
+    split:unmount()
+  end
   -- mount/open the component
   split:mount()
 
@@ -29,7 +35,8 @@ M.show = function(data, type)
   if _HURL_GLOBAL_CONFIG.auto_close then
     -- unmount component when buffer is closed
     split:on(event.BufLeave, function()
-      split:unmount()
+      quit()
+      -- split:unmount()
     end)
   end
 
@@ -75,12 +82,6 @@ M.show = function(data, type)
     vim.api.nvim_feedkeys('zx', 'n', true)
   end, 200)
 
-  local function quit()
-    -- set buffer name to empty string so it wouldn't conflict when next time buffer opened
-    vim.api.nvim_buf_set_name(split.bufnr, '')
-    vim.cmd('q')
-    split:unmount()
-  end
   split:map('n', _HURL_GLOBAL_CONFIG.mappings.close, function()
     quit()
   end)


### PR DESCRIPTION

## WHAT

Steps to reproduce bug without fix:

- have plugin configured to show results in split mode
- execute a request
- close the output buffer with `:q`
- try to execute another request
- error is triggered

```
...javo/.local/share/nvim/lazy/hurl.nvim/lua/hurl/split.lua:27: Failed to rename buffer
stack traceback:
	[C]: in function 'nvim_buf_set_name'
	...javo/.local/share/nvim/lazy/hurl.nvim/lua/hurl/split.lua:27: in function 'show'
	.../javo/.local/share/nvim/lazy/hurl.nvim/lua/hurl/main.lua:248: in function <.../javo/.local/share/nvim/lazy/hurl.nvim/lua/hurl/main.lua:200>
```

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY

Annoying bug 🐛

## HOW

Call the `quit()` function, which has some extra functionality, instead of `split:unmount()` directly on the `BufLeave` event handler.

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved buffer management when exiting components, enhancing user experience during navigation.

- **Bug Fixes**
	- Ensured that buffers are properly cleaned up and closed to prevent conflicts upon reopening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->