### PR TITLE
Adds the file-root in the hurl cli command if there is a file or Mult…

### DIFF
--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -193,8 +193,8 @@ local function execute_hurl_cmd(opts, callback)
   -- Include the HTTP headers in the output and do not colorize output.
   local cmd = vim.list_extend({ 'hurl', '-i', '--no-color' }, opts)
   if is_file_mode then
-    local cwd = vim.fn.getcwd()
-    vim.list_extend(cmd, { '--file-root', cwd })
+    local file_root = _HURL_GLOBAL_CONFIG.file_root or vim.fn.getcwd()
+    vim.list_extend(cmd, { '--file-root', file_root })
   end
   response = {}
 

--- a/lua/hurl/main.lua
+++ b/lua/hurl/main.lua
@@ -146,6 +146,8 @@ local function execute_hurl_cmd(opts, callback)
 
   local is_verbose_mode = vim.tbl_contains(opts, '--verbose')
   local is_json_mode = vim.tbl_contains(opts, '--json')
+  local is_file_mode = utils.has_file_in_opts(opts)
+
   if
     not _HURL_GLOBAL_CONFIG.auto_close
     and not is_verbose_mode
@@ -190,6 +192,10 @@ local function execute_hurl_cmd(opts, callback)
 
   -- Include the HTTP headers in the output and do not colorize output.
   local cmd = vim.list_extend({ 'hurl', '-i', '--no-color' }, opts)
+  if is_file_mode then
+    local cwd = vim.fn.getcwd()
+    vim.list_extend(cmd, { '--file-root', cwd })
+  end
   response = {}
 
   utils.log_info('hurl: running command' .. vim.inspect(cmd))

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -288,7 +288,7 @@ util.find_env_files_in_folders = function()
 end
 util.has_file_in_opts = function(opts)
   if #opts == 0 then
-    print('Error: No file path provided in opts.')
+    vim.notify('Error: No file path provided in opts.', vim.log.levels.ERROR)
     return false
   end
 

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -288,7 +288,7 @@ util.find_env_files_in_folders = function()
 end
 util.has_file_in_opts = function(opts)
   if #opts == 0 then
-    vim.notify('Error: No file path provided in opts.', vim.log.levels.ERROR)
+    vim.notify('No file path provided in opts.', vim.log.levels.DEBUG)
     return false
   end
 

--- a/lua/hurl/utils.lua
+++ b/lua/hurl/utils.lua
@@ -286,5 +286,30 @@ util.find_env_files_in_folders = function()
 
   return env_files
 end
+util.has_file_in_opts = function(opts)
+  if #opts == 0 then
+    print('Error: No file path provided in opts.')
+    return false
+  end
+
+  local file_path = opts[1]
+
+  local file = io.open(file_path, 'r')
+  if not file then
+    print('Error: Failed to open file: ' .. file_path)
+    return false
+  end
+
+  for line in file:lines() do
+    if line:lower():find('file') or line:lower():find('multipart') then
+      file:close() -- Close the file before returning
+      return true -- Return true if any line contains the keyword
+    end
+  end
+
+  file:close()
+
+  return false
+end
 
 return util


### PR DESCRIPTION
Simple change to allow usage of the CWD with hurl to use endpoints that require uploading files.

## WHAT

Adding the functionality to use local files of the project with hurl through the `--file-root` command.
Example

```
POST {{HOST}}/upload/{{GROUP}}/{{CONVERSATION}}/ad_hoc/upload
Authorization: Bearer {{BEARER}}
[MultipartFormData]
file: file,src/tests/files/doc1.pdf;type=application/pdf
url: ""
```
should work now. 

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->
[Link to issue](https://github.com/jellydn/hurl.nvim/issues/195)

## WHY
Hurl does not allow by default usage of documents if the path is not specified. 
## HOW
Adding current path to the hurl if there is a file uploaded (Multipart + file must exist). However modification is needed if there is a need for documents not within the project.

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--file-root` option to `hurl` command for file uploads using CWD.
> 
>   - **Behavior**:
>     - Adds `--file-root` with CWD to `hurl` command if file upload is detected in `execute_hurl_cmd()` in `main.lua`.
>     - Uses `has_file_in_opts()` in `utils.lua` to check for file uploads in options.
>   - **Functions**:
>     - Adds `has_file_in_opts()` in `utils.lua` to determine if options include file uploads.
>   - **Misc**:
>     - Updates `execute_hurl_cmd()` in `main.lua` to extend command with `--file-root` when necessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fhurl.nvim&utm_source=github&utm_medium=referral)<sup> for 985ae22e2a264a98ef712e9b8215a40a8906e693. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command option to specify a file root based on the current directory when a file option is included.
	- Added functionality to check for file paths in command options, enhancing error handling and validation.
	- Enhanced output handling to support JSON responses and improved logging.

- **Bug Fixes**
	- Improved error messaging for missing or inaccessible file paths in command options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->